### PR TITLE
Remove extra title tag

### DIFF
--- a/web/app/themes/codecorps/templates/head.php
+++ b/web/app/themes/codecorps/templates/head.php
@@ -1,7 +1,6 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title><?php wp_title(); ?></title>
   <meta name="description" content="Contribute to software projects for social good.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
Sage theme supports WP 4.1 title-tag feature which resulted in a duplicate title tag.

Thanks,
Cody

Issue: https://github.com/code-corps/blog.codecorps.org-site/issues/9
Reference: https://roots.io/sage/docs/theme-configuration-and-setup/#title-tag-support